### PR TITLE
Fix bug when NSString object use method  ' - (M3U8SegmentInfoList *)m…

### DIFF
--- a/M3U8Kit/NSString+m3u8.h
+++ b/M3U8Kit/NSString+m3u8.h
@@ -16,6 +16,6 @@
 - (BOOL)isMasterPlaylist;
 - (BOOL)isMediaPlaylist;
 
-- (M3U8SegmentInfoList *)m3u8SegementInfoListValueRelativeToURL:(NSURL *)baseURL;
+- (M3U8SegmentInfoList *)m3u8SegementInfoListValueRelativeToURL:(NSString *)baseURL;
 
 @end

--- a/M3U8Kit/NSString+m3u8.m
+++ b/M3U8Kit/NSString+m3u8.m
@@ -50,7 +50,7 @@
     return NO;
 }
 
-- (M3U8SegmentInfoList *)m3u8SegementInfoListValueRelativeToURL:(NSURL *)baseURL {
+- (M3U8SegmentInfoList *)m3u8SegementInfoListValueRelativeToURL:(NSString *)baseURL {
     // self == @""
     if (0 == self.length)
         return nil;


### PR DESCRIPTION
…3u8SegementInfoListValueRelativeToURL:(NSString *)baseURL' create M3U8SegmentInfoList object.

 A M3U8SegmentInfo object's 'baseURL' property define is '- (NSString *)mediaURL',but when init a M3U8SegmentInfo object the 'baseURL' parame is  a NSURL object.