### PR TITLE
M3U8 media playlist reading fixes

### DIFF
--- a/Source/Media Playlist/M3U8LineReader.h
+++ b/Source/Media Playlist/M3U8LineReader.h
@@ -1,0 +1,18 @@
+//
+//  M3U8LineReader.h
+//  M3U8Kit
+//
+//  Created by Noam Tamim on 22/03/2018.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface M3U8LineReader : NSObject
+    
+@property (nonatomic, readonly, strong) NSArray<NSString*>* lines;
+@property (atomic, readonly, assign) NSUInteger index;
+    
+- (instancetype)initWithText:(NSString*)text;
+- (NSString*)next;
+
+@end

--- a/Source/Media Playlist/M3U8LineReader.m
+++ b/Source/Media Playlist/M3U8LineReader.m
@@ -1,0 +1,33 @@
+//
+//  M3U8LineReader.m
+//  M3U8Kit
+//
+//  Created by Noam Tamim on 22/03/2018.
+//
+
+#import "M3U8LineReader.h"
+
+
+@implementation M3U8LineReader
+- (instancetype)initWithText:(NSString*)text
+{
+    self = [super init];
+    if (self) {
+        _lines = [text componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+    }
+    return self;
+}
+
+- (NSString*)next {
+    while (_index < _lines.count) {
+        NSString* line = [_lines[_index] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        _index++;
+        
+        if (line.length > 0) {
+            return line;
+        }
+    }
+    return nil;
+}
+@end
+

--- a/Source/Media Playlist/M3U8MediaPlaylist.m
+++ b/Source/Media Playlist/M3U8MediaPlaylist.m
@@ -10,6 +10,7 @@
 #import "NSString+m3u8.h"
 #import "M3U8TagsAndAttributes.h"
 #import "NSURL+easy.h"
+#import "M3U8LineReader.h"
 
 @interface M3U8MediaPlaylist()
 
@@ -64,28 +65,15 @@
     return [array copy];
 }
 
-- (NSString*)nextLineFrom:(NSArray<NSString*>*)lines at:(NSInteger*)index {
-    
-    while (*index < lines.count) {
-        NSString* line = [lines[*index] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-        (*index)++;
-        if (line.length > 0) {
-            return line;
-        }
-    }
-    return nil;
-}
-
 - (void)parseMediaPlaylist
 {
     self.segmentList = [[M3U8SegmentInfoList alloc] init];
     
-    NSArray *lines = [self.originalText componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
-    
-    NSInteger count = 0;
+    M3U8LineReader* lines = [[M3U8LineReader alloc] initWithText:self.originalText];
     
     while (true) {
-        NSString* line = [self nextLineFrom:lines at:&count];
+        
+        NSString* line = [lines next];
         if (!line) {
             break;
         }
@@ -107,7 +95,7 @@
             [params setValue:line forKey:M3U8_EXTINF_DURATION];
             
             //then get URI
-            NSString *nextLine = [self nextLineFrom:lines at:&count];
+            NSString *nextLine = [lines next];
             [params setValue:nextLine forKey:M3U8_EXTINF_URI];
             
             M3U8SegmentInfo *segment = [[M3U8SegmentInfo alloc] initWithDictionary:params];
@@ -119,3 +107,4 @@
 }
 
 @end
+


### PR DESCRIPTION
Note that this change includes the fix from #11. It fixes the way it reads lines, in particular the new code doesn't handle files with `\r\n` properly.